### PR TITLE
Update Jekyll-Geolexica dependency and config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/geolexica/geolexica-server.git
-  revision: 1a099c5555b8350edd9beb81cd4b8a2a4084f9de
+  revision: 40a02b4ce56a69b17a192897c2bcb95889735a6e
   specs:
     jekyll-geolexica (0.1.0)
       jekyll (~> 3.8.5)

--- a/_config.yml
+++ b/_config.yml
@@ -28,10 +28,6 @@ tagline: >-
 description: >-
   The authoritative glossary for OSGeo.
 
-# Used for copyright notice and possibly more.
-# TODO
-org: {}
-
 baseurl: ""
 url: "https://osgeo.geolexica.org"
 


### PR DESCRIPTION
Slight updates to `_config.yml` (i.e. removal of now unneeded "org" entry) are a consequence of https://github.com/geolexica/geolexica-server/pull/47.