### PR TITLE
Tidy up generated JSONs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :jekyll_plugins do
   gem "jekyll-geolexica", github: "geolexica/geolexica-server"
   gem "jekyll-data"
   gem "jekyll-asciidoc"
+  gem "jekyll-tidy-json"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
       sass (~> 3.4)
     jekyll-theme-isotc211-helpers (0.5.4)
       jekyll (~> 3.8)
+    jekyll-tidy-json (1.1.0)
+      jekyll (>= 3.8, < 5)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (1.17.0)
@@ -82,6 +84,7 @@ DEPENDENCIES
   jekyll-geolexica!
   jekyll-plugin-frontend-build (~> 0.0.2)
   jekyll-theme-isotc211-helpers (~> 0.5.4)
+  jekyll-tidy-json
   tzinfo-data
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -82,6 +82,9 @@ geolexica:
     - html
     - json
 
+tidy_json:
+  pretty: true
+
 exclude:
   - osgeo-glossary/
   - README.adoc


### PR DESCRIPTION
Use Jekyll-Tidy-JSON to prettify generated JSONs (easier to spot differences in Git), and to ensure that they are not malformed.