### PR TITLE
feat: update glossary to v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "geolexica-site"
+gem "geolexica-site", "~> 1.7.7"

--- a/_config.yml
+++ b/_config.yml
@@ -90,7 +90,9 @@ defaults:
       show_header_meta: true
 
 geolexica:
-  concepts_glob: "../osgeo-glossary/concepts/*.yaml"
+  glossary_path: "../osgeo-glossary/geolexica"
+  concepts_glob: "../osgeo-glossary/geolexica/concept/*.yaml"
+  localized_concepts_path: "../osgeo-glossary/geolexica/localized_concept"
   term_languages:
     - eng
   formats:


### PR DESCRIPTION
This PR contains the changes required in [osgeo.geolexica.org](https://github.com/geolexica/osgeo.geolexica.org) to update the glossary structure to V2.
Depends on https://github.com/geolexica/osgeo-glossary/pull/28