### PR TITLE
Switch to concept-browser SPA deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,28 +1,83 @@
-name: deploy
+name: build_deploy
 
 on:
   push:
-    branches:
-      - main
-      - staging
+    branches: [main]
   pull_request:
   repository_dispatch:
-    types:
-    - deploy
+    types: [deploy]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  build-deploy:
-    uses: geolexica/ci/.github/workflows/site-deploy.yml@main
-    with:
-      repository: geolexica/osgeo-glossary
-      concepts-path: osgeo-glossary
-      environment-name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
-      environment-url: ${{ github.ref == 'refs/heads/main' && 'https://osgeo.geolexica.org' || 'https://osgeo-staging.geolexica.org' }}
-      production-branch: refs/heads/main
-      staging-branch: staging
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      aws-region: ${{ secrets.AWS_REGION }}
-      aws-cf-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-      aws-s3-bucket-name: ${{ secrets.S3_BUCKET_NAME }}
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://osgeo.geolexica.org
+    steps:
+      - name: Checkout vocabulary-browser
+        uses: actions/checkout@v4
+        with:
+          repository: glossarist/vocabulary-browser
+          ref: main
+          path: vocabulary-browser
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: vocabulary-browser/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: vocabulary-browser
+
+      - name: Fetch datasets (download GCR packages)
+        run: npm run fetch-datasets
+        working-directory: vocabulary-browser
+        env:
+          SITE_ID: osgeo
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate data
+        run: npm run generate-data
+        working-directory: vocabulary-browser
+        env:
+          SITE_ID: osgeo
+
+      - name: Build edges
+        run: node scripts/build-edges.js
+        working-directory: vocabulary-browser
+
+      - name: Build SPA
+        run: npm run build
+        working-directory: vocabulary-browser
+        env:
+          SITE_ID: osgeo
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: vocabulary-browser/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Replace the Jekyll-based build with the Glossarist concept-browser SPA.

### Changes

- **New workflow**: `build.yml` checks out `glossarist/vocabulary-browser`, runs the full pipeline with `SITE_ID=osgeo`
- **Pipeline**: fetch GCR → generate data → build edges → Vite build → GitHub Pages deploy
- **No more Jekyll**: removes dependency on geolexica/ci reusable workflow and Jekyll build

### Depends on

- glossarist/vocabulary-browser#2 (site config, URI routing, theming system)

### Deployment flow

```
Push to main → Checkout vocabulary-browser → SITE_ID=osgeo npm run fetch-datasets
→ npm run generate-data → build edges → npm run build → GitHub Pages deploy
```

The concept-browser will use `configs/osgeo.yml` which declares:
- OSGeo dataset only (single dataset deployment)
- Routing to electropedia.org for IEV references
- Routing to isotc204/isotc211 geolexica sites
- OSGeo branding (green, Miriam Libre + Sintony fonts, OSGeo logo)