### PR TITLE
Use full GCR package for compiled format support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,51 +24,24 @@ jobs:
       name: production
       url: https://osgeo.geolexica.org
     steps:
-      - name: Checkout vocabulary-browser
-        uses: actions/checkout@v4
-        with:
-          repository: glossarist/vocabulary-browser
-          ref: main
-          path: vocabulary-browser
+      - uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: vocabulary-browser/package-lock.json
 
-      - name: Install dependencies
-        run: npm ci
-        working-directory: vocabulary-browser
+      - name: Install concept-browser
+        run: npm install @glossarist/concept-browser
 
-      - name: Fetch datasets (download GCR packages)
-        run: npm run fetch-datasets
-        working-directory: vocabulary-browser
+      - name: Build site
+        run: npx concept-browser build
         env:
-          SITE_ID: osgeo
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate data
-        run: npm run generate-data
-        working-directory: vocabulary-browser
-        env:
-          SITE_ID: osgeo
-
-      - name: Build edges
-        run: node scripts/build-edges.js
-        working-directory: vocabulary-browser
-
-      - name: Build SPA
-        run: npm run build
-        working-directory: vocabulary-browser
-        env:
-          SITE_ID: osgeo
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: vocabulary-browser/dist
+          path: dist
 
   deploy:
     environment:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,28 +1,83 @@
-name: deploy
+name: build_deploy
 
 on:
   push:
-    branches:
-      - main
-      - staging
+    branches: [main]
   pull_request:
   repository_dispatch:
-    types:
-    - deploy
+    types: [deploy]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  build-deploy:
-    uses: geolexica/ci/.github/workflows/site-deploy.yml@main
-    with:
-      repository: geolexica/osgeo-glossary
-      concepts-path: osgeo-glossary
-      environment-name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
-      environment-url: ${{ github.ref == 'refs/heads/main' && 'https://osgeo.geolexica.org' || 'https://osgeo-staging.geolexica.org' }}
-      production-branch: refs/heads/main
-      staging-branch: staging
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      aws-region: ${{ secrets.AWS_REGION }}
-      aws-cf-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-      aws-s3-bucket-name: ${{ secrets.S3_BUCKET_NAME }}
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://osgeo.geolexica.org
+    steps:
+      - name: Checkout vocabulary-browser
+        uses: actions/checkout@v4
+        with:
+          repository: glossarist/vocabulary-browser
+          ref: main
+          path: vocabulary-browser
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: vocabulary-browser/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: vocabulary-browser
+
+      - name: Fetch datasets (download GCR packages)
+        run: npm run fetch-datasets
+        working-directory: vocabulary-browser
+        env:
+          SITE_ID: osgeo
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate data
+        run: npm run generate-data
+        working-directory: vocabulary-browser
+        env:
+          SITE_ID: osgeo
+
+      - name: Build edges
+        run: node scripts/build-edges.js
+        working-directory: vocabulary-browser
+
+      - name: Build SPA
+        run: npm run build
+        working-directory: vocabulary-browser
+        env:
+          SITE_ID: osgeo
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: vocabulary-browser/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site-config.yml
+++ b/site-config.yml
@@ -1,0 +1,96 @@
+id: osgeo
+domain: osgeo.geolexica.org
+title: OSGeo Lexicon
+subtitle: Open Source Geospatial Glossary
+description: Glossary of geospatial terms from the Open Source Geospatial Foundation.
+
+datasets:
+  - id: osgeo
+    uri: "https://glossarist.org/osgeo/*"
+    gcrPackage: https://github.com/geolexica/osgeo-glossary/releases/latest/download/osgeo.gcr
+    sourceRepo: https://github.com/geolexica/osgeo-glossary
+    title: "OSGeo Lexicon"
+    description: "Open Source Geospatial Foundation glossary of geospatial terms"
+    owner: OSGeo
+    color: "#4CB05B"
+
+routing:
+  - uri: "urn:iec:std:iec:60050:*"
+    type: url
+    url: "https://electropedia.org/iev/iev.nsf/display?openform&ievref={conceptId}"
+    label: "IEC Electropedia"
+
+  - uri: "https://glossarist.org/iev/*"
+    type: url
+    url: "https://electropedia.org/iev/iev.nsf/display?openform&ievref={conceptId}"
+    label: "IEC Electropedia"
+
+  - uri: "urn:iso:std:iso:14812:*"
+    type: site
+    baseUrl: "https://isotc204.geolexica.org"
+    label: "ISO/TC 204 ITS Vocabulary"
+
+  - uri: "https://glossarist.org/isotc204/*"
+    type: site
+    baseUrl: "https://isotc204.geolexica.org"
+    label: "ISO/TC 204 ITS Vocabulary"
+
+  - uri: "https://glossarist.org/isotc211/*"
+    type: site
+    baseUrl: "https://isotc211.geolexica.org"
+    label: "ISO/TC 211 Glossary"
+
+branding:
+  primaryColor: "#4CB05B"
+  darkColor: "#00393F"
+  fonts:
+    header:
+      family: "Miriam Libre"
+      source: "google"
+      weights: [400, 700]
+    body:
+      family: "Sintony"
+      source: "google"
+      weights: [400, 700]
+  logo:
+    path: /logos/osgeo-emblem.svg
+    alt: "OSGeo"
+    url: "/"
+    remoteUrl: "https://github.com/OSGeo/osgeo/raw/refs/heads/master/marketing/branding/logo/osgeo-emblem-cmyk.svg"
+  footerLogo:
+    path: /logos/osgeo-logo.svg
+    alt: "OSGeo"
+    url: "https://www.osgeo.org"
+    remoteUrl: "https://github.com/OSGeo/osgeo/raw/refs/heads/master/marketing/branding/logo/osgeo-logo-cmyk.svg"
+  ownerName: OSGeo
+  ownerUrl: https://www.osgeo.org
+
+features:
+  news: false
+  stats: true
+  graph: true
+  about: true
+  search: true
+  poweredBy:
+    title: "Glossarist"
+    url: "https://glossarist.org"
+
+social:
+  github: "https://github.com/geolexica/osgeo-glossary"
+
+nav:
+  - label: Concepts
+    route: home
+  - label: Search
+    route: search
+  - label: Graph
+    route: graph
+
+footerNav:
+  - label: About
+    route: about
+
+defaults:
+  language: eng
+
+email: admin@osgeo.org

--- a/site-config.yml
+++ b/site-config.yml
@@ -7,7 +7,7 @@ description: Glossary of geospatial terms from the Open Source Geospatial Founda
 datasets:
   - id: osgeo
     uri: "https://glossarist.org/osgeo/*"
-    gcrPackage: https://github.com/geolexica/osgeo-glossary/releases/latest/download/osgeo.gcr
+    gcrPackage: https://github.com/geolexica/osgeo-glossary/releases/latest/download/osgeo-full.gcr
     sourceRepo: https://github.com/geolexica/osgeo-glossary
     title: "OSGeo Lexicon"
     description: "Open Source Geospatial Foundation glossary of geospatial terms"
@@ -56,12 +56,12 @@ branding:
     path: /logos/osgeo-emblem.svg
     alt: "OSGeo"
     url: "/"
-    remoteUrl: "https://github.com/OSGeo/osgeo/raw/refs/heads/master/marketing/branding/logo/osgeo-emblem-cmyk.svg"
+    localPath: logos/osgeo-emblem.svg
   footerLogo:
     path: /logos/osgeo-logo.svg
     alt: "OSGeo"
     url: "https://www.osgeo.org"
-    remoteUrl: "https://github.com/OSGeo/osgeo/raw/refs/heads/master/marketing/branding/logo/osgeo-logo-cmyk.svg"
+    localPath: logos/osgeo-logo.svg
   ownerName: OSGeo
   ownerUrl: https://www.osgeo.org
 


### PR DESCRIPTION
## Changes
- Reference osgeo-full.gcr from GitHub Releases
- Enables per-concept format downloads (Turtle, YAML) in the concept browser

Depends on geolexica/osgeo-glossary#33 (dual GCR publishing).